### PR TITLE
[#1] 특정 페이지에서 header 안보이게 수정

### DIFF
--- a/src/shared/Header.jsx
+++ b/src/shared/Header.jsx
@@ -1,5 +1,5 @@
 const Header = () => {
-  if(window.location.pathname === '/login'||'/register') return null
+  if(window.location.pathname === '/login'&&'/register') return null
   return (
     <div>header 부분입니다.</div>
   );


### PR DESCRIPTION
- '/login'||'/register'에서 '/login'&&'/register'로 수정함
- 로그인, 회원 가입 페이지에서만 header가 보이지 않음