### PR TITLE
[#6] 맥주 리스트 페이지 UI 구현

### DIFF
--- a/src/components/HashtagBox.jsx
+++ b/src/components/HashtagBox.jsx
@@ -1,0 +1,51 @@
+import styled from "styled-components";
+
+const HashtagBox = ({ tags, removeTag }) => {
+  return (
+    <Container>
+      {tags.map((tag, index) => (
+        <TagSection key={index}>
+          <TagTitle>{tag}</TagTitle>
+          <RemoveButton onClick={() => removeTag(tag)}>
+            X
+          </RemoveButton>
+        </TagSection>
+      ))}
+    </Container>
+  );
+};
+
+const Container = styled.div`
+  margin-top: 20px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 22px;
+`;
+
+const TagSection = styled.div`
+  height: 28px;
+  margin: 0;
+  background-color: #D9D9D9;
+  border-radius: 4px;
+`;
+
+const TagTitle = styled.span`
+  height: 100%;
+  padding: 3px 10px;  
+  font-weight: 400;
+  font-size: 15px;
+  color: #666;
+`;
+
+const RemoveButton = styled.button`
+  width: 24px;
+  height: 100%;
+  background-color: #B3B3B3;
+  color: #666;
+  border-radius: 0 4px 4px 0;
+  padding: 3px;
+  border:none;
+  cursor: pointer;
+`;
+
+export default HashtagBox;

--- a/src/components/HashtagBox.jsx
+++ b/src/components/HashtagBox.jsx
@@ -16,6 +16,7 @@ const HashtagBox = ({ tags, removeTag }) => {
 };
 
 const Container = styled.div`
+  height: 28px;
   margin-top: 20px;
   display: flex;
   flex-wrap: wrap;

--- a/src/pages/List.jsx
+++ b/src/pages/List.jsx
@@ -2,6 +2,7 @@ import React, { useState } from "react";
 import styled from "styled-components";
 import HashtagBox from "../components/HashtagBox";
 import BeerItem from "../components/BeerItem";
+import Navigation from "../shared/Navigation";
 import { Link } from "react-router-dom";
 
 const List = () => {
@@ -36,6 +37,7 @@ const List = () => {
 
   return (
     <Wrapper> 
+      <Navigation />
       <HashtagsContainer>
         {tags.map((tag, index) => (
           <div>
@@ -78,7 +80,6 @@ const HashtagsContainer = styled.div`
   color: #666;
   font-size: 15px;
   font-weight: 400;
-  margin-top: 30px;
 `;
 
 const HashTag = styled.span`
@@ -113,6 +114,7 @@ const ItemContainer = styled.div`
   display: grid;
   grid-template-columns: repeat(4,1fr);
   grid-gap: 9px;
+  margin-bottom: 20px;
 `;
 
 export default List;

--- a/src/pages/List.jsx
+++ b/src/pages/List.jsx
@@ -1,6 +1,8 @@
 import React, { useState } from "react";
 import styled from "styled-components";
 import HashtagBox from "../components/HashtagBox";
+import BeerItem from "../components/BeerItem";
+import { Link } from "react-router-dom";
 
 const List = () => {
   const tags = ["#달달함", "#부드러움", "#상큼함", "#깔끔함", "#쓴맛", "#쌉쌀함", "#과일향", "#새콤달콤"];
@@ -15,6 +17,22 @@ const List = () => {
   const removeTag = (tag) => {
     setSelectTags(selectTags.filter((selectTag) => selectTag !== tag));
   }; 
+
+  // 임시 맥주 데이터 사용
+  const beerData = [
+    {id: 1, image: require('../assets/FirstJuiceLarger.png'), name: '첫즙라거', like: 5, tags: ['달달함', '부드러움']},
+    {id: 2, image: require('../assets/LemonRamalade.png'), name: '레몬라말레이드', like: 22, tags: ['달달함', '부드러움']},
+    {id: 3, image: require('../assets/LargerOnTheBeach.png'), name: '라거 온 더 비치', like: 5, tags: ['달달함', '부드러움']},
+    {id: 4, image: require('../assets/DarkLarger.png'), name: '다크 라거', like: 22, tags: ['달달함', '부드러움', '쓴맛']},
+    {id: 5, image: require('../assets/LemonRamalade.png'), name: '레몬라말레이드', like: 22, tags: ['달달함', '부드러움']},
+    {id: 6, image: require('../assets/LargerOnTheBeach.png'), name: '라거 온 더 비치', like: 5, tags: ['달달함', '부드러움']},
+    {id: 7, image: require('../assets/DarkLarger.png'), name: '다크 라거', like: 22, tags: ['달달함', '부드러움', '쓴맛']},
+    {id: 8, image: require('../assets/LemonRamalade.png'), name: '레몬라말레이드', like: 22, tags: ['달달함', '부드러움']},
+    {id: 9, image: require('../assets/LargerOnTheBeach.png'), name: '라거 온 더 비치', like: 5, tags: ['달달함', '부드러움']},
+    {id: 10, image: require('../assets/DarkLarger.png'), name: '다크 라거', like: 22, tags: ['달달함', '부드러움', '쓴맛']},
+    {id: 11, image: require('../assets/LemonRamalade.png'), name: '레몬라말레이드', like: 22, tags: ['달달함', '부드러움']},
+    {id: 12, image: require('../assets/LargerOnTheBeach.png'), name: '라거 온 더 비치', like: 5, tags: ['달달함', '부드러움']},
+  ]; 
 
   return (
     <Wrapper> 
@@ -36,6 +54,14 @@ const List = () => {
         <Bar>|</Bar>
         <SortButton>좋아요순</SortButton>
       </SortOptions>
+
+      <ItemContainer>
+        {beerData.map((beer, index) => (
+          <Link to={`/beer/${beer.id}`} style={{ textDecoration: "none"}}>
+            <BeerItem key={index} item={beer} />
+          </Link>
+        ))}
+      </ItemContainer>
     </Wrapper>
   );
 };
@@ -79,6 +105,14 @@ const SortButton = styled.button`
 const Bar = styled.span`
   color: #666666B0;
   margin: 0 12px;
+`;
+
+const ItemContainer = styled.div`
+  max-width: 100%;
+  justify-content:space-between;
+  display: grid;
+  grid-template-columns: repeat(4,1fr);
+  grid-gap: 9px;
 `;
 
 export default List;

--- a/src/pages/List.jsx
+++ b/src/pages/List.jsx
@@ -30,6 +30,12 @@ const List = () => {
       </HashtagsContainer>
 
       <HashtagBox tags={selectTags} removeTag={removeTag} />
+      
+      <SortOptions>
+        <SortButton>가나다순</SortButton>
+        <Bar>|</Bar>
+        <SortButton>좋아요순</SortButton>
+      </SortOptions>
     </Wrapper>
   );
 };
@@ -55,5 +61,24 @@ const HashTag = styled.span`
   margin-right: 15px;
 `; 
 
+const SortOptions = styled.div`
+  display: flex;
+  margin: 20px 0 30px;
+  justify-content: flex-end;
+`;
+
+const SortButton = styled.button`
+  background-color: transparent;
+  border: none;
+  cursor: pointer;
+  font-size: 15px;
+  font-weight: 400;
+  color: #666666B0;
+`;
+
+const Bar = styled.span`
+  color: #666666B0;
+  margin: 0 12px;
+`;
 
 export default List;

--- a/src/pages/List.jsx
+++ b/src/pages/List.jsx
@@ -1,5 +1,59 @@
+import React, { useState } from "react";
+import styled from "styled-components";
+import HashtagBox from "../components/HashtagBox";
+
 const List = () => {
-    return <div>리스트 페이지입니다.</div>;
+  const tags = ["#달달함", "#부드러움", "#상큼함", "#깔끔함", "#쓴맛", "#쌉쌀함", "#과일향", "#새콤달콤"];
+  const [selectTags, setSelectTags] = useState([]);
+
+  const addHashtag = (tag) => {
+    if(!selectTags.includes(tag)) {
+      setSelectTags([...selectTags, tag]);
+    }
   };
-  
-  export default List;
+
+  const removeTag = (tag) => {
+    setSelectTags(selectTags.filter((selectTag) => selectTag !== tag));
+  }; 
+
+  return (
+    <Wrapper> 
+      <HashtagsContainer>
+        {tags.map((tag, index) => (
+          <div>
+            <HashTag key={index} onClick={() => addHashtag(tag)}>
+              {tag}
+            </HashTag>
+            {index < tags.length - 1 && <span>|</span>}
+          </div>
+        ))}
+      </HashtagsContainer>
+
+      <HashtagBox tags={selectTags} removeTag={removeTag} />
+    </Wrapper>
+  );
+};
+
+const Wrapper = styled.div`
+  max-width: 1075px;
+  margin: 0 auto;
+`;
+
+const HashtagsContainer = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  gap:15px;
+  color: #666;
+  font-size: 15px;
+  font-weight: 400;
+  margin-top: 30px;
+`;
+
+const HashTag = styled.span`
+  padding: 5px;
+  cursor: pointer;
+  margin-right: 15px;
+`; 
+
+
+export default List;


### PR DESCRIPTION
## PR 타입
UI 구현

## 반영 브랜치
ui/#6 -> develop

## 변경 사항
![image](https://github.com/FS-2023-FestivalHolic/FH-Front/assets/71203375/ee4fbffd-2dab-41d7-b866-b33eac134ddc)

- '맥주 리스트 페이지' UI 구현
- 해시태그 필터 구현
- 정렬 구현
- HashtagBox 컴포넌트 생성 