### PR TITLE
[#6] 맥주 리스트 페이지 반응형 구현

### DIFF
--- a/src/components/TagSlide.jsx
+++ b/src/components/TagSlide.jsx
@@ -1,0 +1,144 @@
+import React, { useState, useRef, useEffect } from 'react';
+import styled from "styled-components";
+import HashtagBox from './HashtagBox';
+
+const TagSlide = ({items}) => {
+  const containerRef = useRef(null);
+  const [startX, setStartX] = useState(null);
+  const [isDrag, setIsDrag] = useState(false);
+  const [isMobile, setIsMobile] = useState(window.innerWidth <= 390);
+  const [selectTags, setSelectTags] = useState([]);
+  
+  // 모바일용일 때 태그 슬라이드로 전환
+  useEffect(() => {
+    const handleResize = () => {
+      setIsMobile(window.innerWidth <= 390);
+    };
+
+    window.addEventListener('resize', handleResize);
+
+    return () => {
+      window.removeEventListener('resize', handleResize);
+    };
+  }, []);
+  
+  // 태그 드래그
+  const onDragStart = e => {
+    e.preventDefault();
+    setIsDrag(true);
+    setStartX(e.pageX + containerRef.current.scrollLeft);
+  };
+  const onDragEnd = () => {
+    setIsDrag(false);
+  }
+  const onDragMove = e => {
+    if(isDrag) {
+      const {scrollWidth, clientWidth, scrollLeft} = containerRef.current;
+      containerRef.current.scrollLeft = startX - e.pageX;
+      if (scrollLeft === 0) {
+        setStartX(e.pageX); 
+      } else if (scrollWidth <= clientWidth + scrollLeft) {
+        setStartX(e.pageX + scrollLeft); 
+      }
+    }
+  }
+
+  const throttle = (func, ms) => {
+    let throttled = false;
+    return (...args) => {
+      if (!throttled) {
+        throttled = true;
+        setTimeout(() => {
+          func(...args);
+          throttled = false;
+        }, ms);
+      }
+    };
+  };
+
+  const delay = 50;
+  const onThrottleDragMove = throttle(onDragMove, delay);
+
+  const addHashtag = (tag) => {
+    if(!selectTags.includes(tag)) {
+      setSelectTags([...selectTags, tag]);
+    }
+  };
+
+  const removeTag = (tag) => {
+    setSelectTags(selectTags.filter((selectTag) => selectTag !== tag));
+  }; 
+
+  return (
+    <div> {isMobile ? <>
+        {items && (
+          <SlideContainer
+            ref={containerRef}
+            onMouseDown={onDragStart}
+            onMouseUp={onDragEnd}
+            onMouseLeave={onDragEnd}
+            onMouseMove={isDrag ? onThrottleDragMove : null}
+          >
+            <SlideItem>
+              {items.map((item, index) => (
+                <div>
+                  <HashTag key={index} onClick={() => addHashtag(item)}>
+                    {item}
+                  </HashTag>
+                  {index < items.length - 1 && <span>|</span>}
+                </div>
+              ))}
+            </SlideItem>
+          </SlideContainer>
+        )} 
+      </> : 
+      <HashtagsContainer>
+        {items.map((tag, index) => (
+          <div>
+            <HashTag key={index} onClick={() => addHashtag(tag)}>
+              {tag}
+            </HashTag>
+            {index < items.length - 1 && <span>|</span>}
+          </div>
+        ))}
+      </HashtagsContainer>
+    }
+      
+      <HashtagBox tags={selectTags} removeTag={removeTag} />
+    </div>
+  );
+};
+
+const SlideContainer = styled.div`
+  display: flex;
+  overflow: hidden;
+  width: 390px; 
+  margin-bottom: 20px;
+  white-space: nowrap;
+`;
+
+const SlideItem= styled.div`
+  display: flex;
+  flex-wrap: nowrap;
+  gap: 7px;
+  color: #666;
+  font-size: 15px;
+  font-weight: 400;
+`;
+
+const HashTag = styled.span`
+  padding: 5px;
+  cursor: pointer;
+  margin-right: 7px;
+`; 
+
+const HashtagsContainer = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  gap:15px;
+  color: #666;
+  font-size: 15px;
+  font-weight: 400;
+`;
+
+export default TagSlide; 

--- a/src/pages/List.jsx
+++ b/src/pages/List.jsx
@@ -1,23 +1,13 @@
-import React, { useState } from "react";
+import React from 'react';
 import styled from "styled-components";
-import HashtagBox from "../components/HashtagBox";
 import BeerItem from "../components/BeerItem";
 import Navigation from "../shared/Navigation";
+import TagSlide from '../components/TagSlide';
 import { Link } from "react-router-dom";
 
 const List = () => {
   const tags = ["#달달함", "#부드러움", "#상큼함", "#깔끔함", "#쓴맛", "#쌉쌀함", "#과일향", "#새콤달콤"];
-  const [selectTags, setSelectTags] = useState([]);
-
-  const addHashtag = (tag) => {
-    if(!selectTags.includes(tag)) {
-      setSelectTags([...selectTags, tag]);
-    }
-  };
-
-  const removeTag = (tag) => {
-    setSelectTags(selectTags.filter((selectTag) => selectTag !== tag));
-  }; 
+  
 
   // 임시 맥주 데이터 사용
   const beerData = [
@@ -38,19 +28,7 @@ const List = () => {
   return (
     <Wrapper> 
       <Navigation />
-      <HashtagsContainer>
-        {tags.map((tag, index) => (
-          <div>
-            <HashTag key={index} onClick={() => addHashtag(tag)}>
-              {tag}
-            </HashTag>
-            {index < tags.length - 1 && <span>|</span>}
-          </div>
-        ))}
-      </HashtagsContainer>
-
-      <HashtagBox tags={selectTags} removeTag={removeTag} />
-      
+      <TagSlide items={tags}/>
       <SortOptions>
         <SortButton>가나다순</SortButton>
         <Bar>|</Bar>
@@ -73,21 +51,6 @@ const Wrapper = styled.div`
   margin: 0 auto;
 `;
 
-const HashtagsContainer = styled.div`
-  display: flex;
-  flex-wrap: wrap;
-  gap:15px;
-  color: #666;
-  font-size: 15px;
-  font-weight: 400;
-`;
-
-const HashTag = styled.span`
-  padding: 5px;
-  cursor: pointer;
-  margin-right: 15px;
-`; 
-
 const SortOptions = styled.div`
   display: flex;
   margin: 20px 0 30px;
@@ -101,6 +64,10 @@ const SortButton = styled.button`
   font-size: 15px;
   font-weight: 400;
   color: #666666B0;
+
+  &:hover {
+    color: #666;
+  }
 `;
 
 const Bar = styled.span`
@@ -115,6 +82,14 @@ const ItemContainer = styled.div`
   grid-template-columns: repeat(4,1fr);
   grid-gap: 9px;
   margin-bottom: 20px;
+
+  @media (max-width: 390px) {
+    width: 370px;
+    grid-template-columns: repeat(2,1fr);
+    grid-gap: 8px;
+    margin: 14px auto;
+    object-fit: cover;
+  }
 `;
 
 export default List;


### PR DESCRIPTION
## PR 타입
UI 구현

## 반영 브랜치
ui/#6 -> develop

## 변경 사항
![image](https://github.com/FS-2023-FestivalHolic/FH-Front/assets/71203375/b0244c0c-b608-4620-8dcf-758b384d8189)

- 태그 모바일 버전 시 슬라이드로 구현
- TagSlide 컴포넌트 추가
- 가나다순, 좋아요순 hover시 색 변경